### PR TITLE
Remove region parameter from template.yml

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -18,8 +18,6 @@ Globals:
               Ref: CognitoRedirectUriParameter
 
 Parameters:
-  RegionParameter:
-    Type: String
   GitHubClientIdParameter:
     Type: String
   GitHubClientSecretParameter:


### PR DESCRIPTION
Before removing this parameter, I was getting a consistent error
when trying to deploy to lambda/API gateway:

```
An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameters: [RegionParameter] must have values
```
After removing it, the deploy seems to succeed.