### PR TITLE
GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,7 @@ A full OpenID implementation would also include:
 
 **Known issues**
 
-If deployed via lambda, Cognito can't seem to use the discovery endpoint.
-However, the endpoints can be specified manually as described in the getting
-started instructions.
+none
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ You will need to:
   - Authorization callback URL: `https://<Your Cognito Domain>/oauth2/idpresponse`
   - Note down the Client ID and secret
 
+(If you use GitHub Enterprise, you need the API & Login URL. This is usually `https://<GitHub Enterprise Host>/api/v3` and `https://<GitHub Enterprise Host>`.)
+
 Next you need to decide if you'd like to deploy with lambda/API Gateway (follow Step 2a), or as a node server (follow Step 2b)
 
 ### 2a: Deployment with lambda and API Gateway

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Next you need to decide if you'd like to deploy with lambda/API Gateway (follow 
 - Configure the OIDC integration in AWS console for Cognito (described below, but following [these instructions](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-oidc-idp.html)). The following settings are required:
   - Client ID: The GitHub Client ID above
   - Authorize scope: `openid read:user user:email`
-  - Issuer: either `https://<Your API Gateway DNS name>/Prod` (for lambda with API gateway) or `https://<your webserver>/` (for the node server).
+  - Issuer: either `https://<Your API Gateway DNS name>/Prod` (for lambda with API gateway, replace `Prod` with the correct stage name) or `https://<your webserver>/` (for the node server).
   - If you have deployed the web app: Run discovery (big blue button next to Issuer).
   - If you have deployed the lambda/Gateway: For some reason, Cognito is unable to
     do OpenID Discovery. You will need to configure the endpoints manually. They are:

--- a/example-config.sh
+++ b/example-config.sh
@@ -5,6 +5,10 @@ export GITHUB_CLIENT_ID=# <GitHub OAuth App Client ID>
 export GITHUB_CLIENT_SECRET=# <GitHub OAuth App Client Secret>
 export COGNITO_REDIRECT_URI=# https://<Your Cognito Domain>/oauth2/idpresponse
 
+# Variables required if used with GitHub Enterprise
+# GITHUB_API_URL=# https://<GitHub Enterprise Host>/api/v3
+# GITHUB_LOGIN_URL=# https://<GitHub Enterprise Host>
+
 # Variables required if deploying with API Gateway / Lambda
 export BUCKET_NAME=# An S3 bucket name to use as the deployment pipeline
 export STACK_NAME=# The name of the stack to create

--- a/package-lock.json
+++ b/package-lock.json
@@ -2933,13 +2933,16 @@
       }
     },
     "@pact-foundation/pact": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-7.2.0.tgz",
-      "integrity": "sha512-PZkbsz5vkHW5iTfiUw8ONWk+Uxaiql9/VRTRwLzFNO9BDCkHsyZfhNq4SpydxSTeOR5ihWtH3U8PG6malet/ng==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-8.2.6.tgz",
+      "integrity": "sha512-0t9ak0x1+eHO1q4X1HqdkAtacwTauaHcovirO8+/rzb3pPF8op93jEVkpmmG6BkfYHaEytx+nOZlqrfgnY8fcA==",
       "dev": true,
       "requires": {
-        "@pact-foundation/pact-node": "^6.20.0",
+        "@pact-foundation/pact-node": "^8.6.0",
+        "@types/bluebird": "^3.5.20",
+        "@types/bunyan": "^1.8.3",
         "@types/express": "^4.11.1",
+        "bluebird": "~3.5.1",
         "body-parser": "^1.18.2",
         "bunyan": "^1.8.12",
         "cli-color": "^1.1.0",
@@ -2948,7 +2951,9 @@
         "express": "^4.16.3",
         "graphql": "^0.13.2",
         "graphql-tag": "^2.9.1",
-        "lodash": "^4.17.4",
+        "http-proxy": "^1.17.0",
+        "http-proxy-middleware": "^0.19.0",
+        "lodash": "^4.17.11",
         "lodash.isfunction": "3.0.8",
         "lodash.isnil": "4.0.0",
         "lodash.isundefined": "3.0.1",
@@ -2959,15 +2964,15 @@
       }
     },
     "@pact-foundation/pact-node": {
-      "version": "6.21.5",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-6.21.5.tgz",
-      "integrity": "sha512-PkciKaPjwnMoNwe7MSOlD6/ZoSOiUJqzu559JTi5c/XrA5BKw7cPL7lRpsiUrbMW7jsrlYxwmmwj6KlE2kRQpw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-node/-/pact-node-8.6.2.tgz",
+      "integrity": "sha512-zWK/SI5Wfy/cAFlB8jxWSduehk2MKC3Wlk0nHWx+0C/BpSwbJyLtK5mr8OrTd9VqArRI0AVsGhl7L5TGKWjj4A==",
       "dev": true,
       "requires": {
         "@types/q": "1.0.7",
         "bunyan": "1.8.12",
         "bunyan-prettystream": "0.1.3",
-        "caporal": "1.1.0",
+        "caporal": "1.2.0",
         "chalk": "2.3.1",
         "check-types": "7.3.0",
         "decompress": "4.2.0",
@@ -2976,7 +2981,7 @@
         "request": "2.87.0",
         "rimraf": "2.6.2",
         "sumchecker": "^2.0.2",
-        "tar": "4.4.0",
+        "tar": "4.4.2",
         "underscore": "1.8.3",
         "unixify": "1.0.0",
         "url-join": "^4.0.0"
@@ -3092,6 +3097,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
+      "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -3099,6 +3110,15 @@
       "dev": true,
       "requires": {
         "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/bunyan": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
+      "integrity": "sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -3122,9 +3142,9 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/express": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
-      "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+      "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -3133,12 +3153,11 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
-      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/node": "*",
         "@types/range-parser": "*"
       }
@@ -3169,9 +3188,9 @@
       }
     },
     "@types/mime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
       "dev": true
     },
     "@types/node": {
@@ -3186,9 +3205,9 @@
       "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
     "@types/serve-static": {
@@ -4261,9 +4280,9 @@
       }
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -4546,14 +4565,13 @@
       }
     },
     "buffer": {
-      "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -4721,18 +4739,16 @@
       "dev": true
     },
     "caporal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/caporal/-/caporal-1.1.0.tgz",
-      "integrity": "sha512-R5qo2QGoqBM6RvzHonGhUuEJSeqEa4lD1r+cPUEY2+YsXhpQVTS2TvScfIbi6ydFdhzFCNeNUB1v0YrRBvsbdg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/caporal/-/caporal-1.2.0.tgz",
+      "integrity": "sha512-oj2E5hfcivjl+/9M4sHqchXsG+U16NdvmuiZjxXk41Iva5ry7/aPUPg+2jpI1bvWyfnWxBBsGnsoOK0BKi5SFQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.4.7",
         "cli-table3": "^0.5.0",
         "colorette": "1.0.1",
         "fast-levenshtein": "^2.0.6",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.merge": "^4.6.0",
+        "lodash": "4.17.11",
         "micromist": "1.1.0",
         "prettyjson": "^1.2.1",
         "tabtab": "^2.2.2",
@@ -5408,12 +5424,13 @@
       "dev": true
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dashdash": {
@@ -5917,14 +5934,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -5968,14 +5985,14 @@
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -6580,6 +6597,12 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -6824,7 +6847,7 @@
     },
     "external-editor": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
       "requires": {
@@ -7179,9 +7202,9 @@
       "dev": true
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -7999,7 +8022,7 @@
     },
     "graphql": {
       "version": "0.13.2",
-      "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
       "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "dev": true,
       "requires": {
@@ -8007,9 +8030,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.0.tgz",
-      "integrity": "sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
       "dev": true
     },
     "growly": {
@@ -8019,25 +8042,22 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -8226,6 +8246,17 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
     "http-proxy-agent": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
@@ -8233,6 +8264,18 @@
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
       }
     },
     "http-signature": {
@@ -8383,7 +8426,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8523,6 +8566,12 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -8536,6 +8585,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
       "integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -10057,18 +10115,6 @@
       "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g=",
       "dev": true
     },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-      "dev": true
-    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -10416,9 +10462,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         }
       }
@@ -10497,9 +10543,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "dev": true,
       "optional": true
     },
@@ -10542,7 +10588,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.4.5",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "dev": true,
           "optional": true,
@@ -10553,9 +10599,9 @@
       }
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -11026,7 +11072,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -11483,7 +11529,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -11998,6 +12044,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -13531,7 +13583,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -13544,17 +13596,26 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
-      "integrity": "sha512-gJlTiiErwo96K904FnoYWl+5+FBgS+FimU6GMh66XLdLa55al8+d4jeDfPoGwSNHdtWI5FJP6xurmVqhBuGJpQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
+      "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
       "dev": true,
       "requires": {
         "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.3",
-        "minipass": "^2.2.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.2.4",
         "minizlib": "^1.1.0",
         "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
         "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
       }
     },
     "tar-stream": {
@@ -13836,6 +13897,12 @@
       "dev": true,
       "optional": true
     },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -13871,20 +13938,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true,
           "optional": true
         },
@@ -13938,13 +14005,13 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
-      "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "undefsafe": {
@@ -14192,9 +14259,9 @@
       }
     },
     "url-join": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-      "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
-    "@pact-foundation/pact": "^7.2.0",
+    "@pact-foundation/pact": "^8.2.6",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.2",
     "chai": "^4.1.2",

--- a/scripts/create-key.sh
+++ b/scripts/create-key.sh
@@ -10,6 +10,6 @@ KEY_FILE="$PROJECT_ROOT"/jwtRS256.key
 
 if [ ! -f "$KEY_FILE" ]; then
   echo "  --- Creating private key, as it does not exist ---"
-  ssh-keygen -t rsa -b 4096 -f "$KEY_FILE" -N ''
+  ssh-keygen -t rsa -b 4096 -m PEM -f "$KEY_FILE" -N ''
   openssl rsa -in "$KEY_FILE" -pubout -outform PEM -out "$KEY_FILE".pub
 fi

--- a/src/config.js
+++ b/src/config.js
@@ -2,5 +2,7 @@ module.exports = {
   GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
   COGNITO_REDIRECT_URI: process.env.COGNITO_REDIRECT_URI,
+  GITHUB_API_URL: process.env.GITHUB_API_URL,
+  GITHUB_LOGIN_URL: process.env.GITHUB_LOGIN_URL,
   PORT: parseInt(process.env.PORT, 10) || undefined
 };

--- a/src/connectors/controllers.js
+++ b/src/connectors/controllers.js
@@ -1,6 +1,10 @@
 const openid = require('../openid');
 
 module.exports = respond => ({
+  authorize: (client_id, scope, state, response_type) => {
+    const authorizeUrl = openid.getAuthorizeUrl(client_id, scope, state, response_type);
+    respond.redirect(authorizeUrl);
+  },
   userinfo: tokenPromise => {
     tokenPromise
       .then(token => openid.getUserInfo(token))

--- a/src/connectors/lambda/authorize.js
+++ b/src/connectors/lambda/authorize.js
@@ -1,4 +1,5 @@
 const responder = require('./util/responder');
+const controllers = require('../controllers');
 
 module.exports.handler = (event, context, callback) => {
   const {
@@ -8,7 +9,10 @@ module.exports.handler = (event, context, callback) => {
     response_type
   } = event.queryStringParameters;
 
-  responder(callback).redirect(
-    `https://github.com/login/oauth/authorize?client_id=${client_id}&scope=${scope}&state=${state}&response_type=${response_type}`
-  );
+
+  controllers(responder(callback)).authorize(
+    client_id,
+    scope,
+    state,
+    response_type);
 };

--- a/src/connectors/lambda/open-id-configuration.js
+++ b/src/connectors/lambda/open-id-configuration.js
@@ -4,6 +4,6 @@ const controllers = require('../controllers');
 
 module.exports.handler = (event, context, callback) => {
   controllers(responder(callback)).openIdConfiguration(
-    auth.getIssuer(event.headers.Host)
+    auth.getIssuer(event.headers.Host, event.requestContext && event.requestContext.stage)
   );
 };

--- a/src/connectors/lambda/token.js
+++ b/src/connectors/lambda/token.js
@@ -26,6 +26,6 @@ module.exports.handler = (event, context, callback) => {
   controllers(responder(callback)).token(
     code,
     state,
-    auth.getIssuer(event.headers.Host)
+    auth.getIssuer(event.headers.Host, event.requestContext && event.requestContext.stage)
   );
 };

--- a/src/connectors/lambda/util/auth.js
+++ b/src/connectors/lambda/util/auth.js
@@ -22,5 +22,10 @@ module.exports = {
       reject(new Error('No token specified in request'));
     }),
 
-  getIssuer: host => `${host}/Prod`
+  getIssuer: (host, stage) => {
+    const lStage = stage || 'Prod';
+    const issuer = `${host}/${lStage}`;
+    logger.info("Resolved issuer: %s", issuer);
+    return issuer;
+  }
 };

--- a/src/connectors/lambda/util/auth.js
+++ b/src/connectors/lambda/util/auth.js
@@ -25,7 +25,6 @@ module.exports = {
   getIssuer: (host, stage) => {
     const lStage = stage || 'Prod';
     const issuer = `${host}/${lStage}`;
-    logger.info("Resolved issuer: %s", issuer);
     return issuer;
   }
 };

--- a/src/github.js
+++ b/src/github.js
@@ -2,16 +2,19 @@ const axios = require('axios');
 const {
   GITHUB_CLIENT_ID,
   GITHUB_CLIENT_SECRET,
-  COGNITO_REDIRECT_URI
+  COGNITO_REDIRECT_URI,
+  GITHUB_API_URL,
+  GITHUB_LOGIN_URL
 } = require('./config');
 
 const getApiEndpoints = (
-  apiBaseUrl = 'https://api.github.com',
-  loginBaseUrl = 'https://github.com'
+  apiBaseUrl = GITHUB_API_URL || 'https://api.github.com',
+  loginBaseUrl = GITHUB_LOGIN_URL || 'https://github.com'
 ) => ({
   userDetails: `${apiBaseUrl}/user`,
   userEmails: `${apiBaseUrl}/user/emails`,
-  oauthToken: `${loginBaseUrl}/login/oauth/access_token`
+  oauthToken: `${loginBaseUrl}/login/oauth/access_token`,
+  oauthAuthorize: `${loginBaseUrl}/login/oauth/authorize`
 });
 
 const check = response => {
@@ -43,9 +46,11 @@ const gitHubGet = (url, accessToken) =>
     }
   });
 
-module.exports = baseUrl => {
-  const urls = getApiEndpoints(baseUrl, baseUrl);
+module.exports = (apiBaseUrl, loginBaseUrl) => {
+  const urls = getApiEndpoints(apiBaseUrl, loginBaseUrl || apiBaseUrl);
   return {
+    getAuthorizeUrl: (client_id, scope, state, response_type) =>
+      `${urls.oauthAuthorize}?client_id=${client_id}&scope=${encodeURIComponent(scope)}&state=${state}&response_type=${response_type}`,
     getUserDetails: accessToken =>
       gitHubGet(urls.userDetails, accessToken).then(check),
     getUserEmails: accessToken =>

--- a/src/github.pact.test.js
+++ b/src/github.pact.test.js
@@ -5,7 +5,9 @@ const github = require('./github');
 jest.mock('./config', () => ({
   COGNITO_REDIRECT_URI: 'COGNITO_REDIRECT_URI',
   GITHUB_CLIENT_SECRET: 'GITHUB_CLIENT_SECRET',
-  GITHUB_CLIENT_ID: 'GITHUB_CLIENT_ID'
+  GITHUB_CLIENT_ID: 'GITHUB_CLIENT_ID',
+  GITHUB_API_URL: 'GITHUB_API_URL',
+  GITHUB_LOGIN_URL: 'GITHUB_LOGIN_URL',
 }));
 
 describe('GitHub Client Pact', () => {
@@ -205,6 +207,16 @@ describe('GitHub Client Pact', () => {
           .catch(() => {
             done();
           });
+      });
+    });
+  });
+
+  describe('Authorization endpoint' , () => {
+    describe('always', () => {
+      it('returns a redirect url', () => {
+        expect(github(PACT_BASE_URL)
+          .getAuthorizeUrl('client_id', 'scope', 'state', 'response_type')).to.equal(
+            `${PACT_BASE_URL}/login/oauth/authorize?client_id=client_id&scope=scope&state=state&response_type=response_type`);
       });
     });
   });

--- a/src/openid.js
+++ b/src/openid.js
@@ -42,6 +42,8 @@ const getUserInfo = accessToken =>
       })
   ]).then(claims => claims.reduce((acc, claim) => ({ ...acc, ...claim }), {}));
 
+const getAuthorizeUrl = (client_id, scope, state, response_type) =>  github().getAuthorizeUrl(client_id, scope, state, response_type);
+
 const getTokens = (code, state, host) =>
   github()
     .getToken(code, state)
@@ -122,4 +124,4 @@ const getConfigFor = host => ({
   ]
 });
 
-module.exports = { getTokens, getUserInfo, getJwks, getConfigFor };
+module.exports = { getTokens, getUserInfo, getJwks, getConfigFor, getAuthorizeUrl };

--- a/src/openid.js
+++ b/src/openid.js
@@ -92,7 +92,7 @@ const getConfigFor = host => ({
   userinfo_endpoint: `https://${host}/userinfo`,
   // check_session_iframe: 'https://server.example.com/connect/check_session',
   // end_session_endpoint: 'https://server.example.com/connect/end_session',
-  jwks_uri: `https://${host}/jwks.json`,
+  jwks_uri: `https://${host}/.well-known/jwks.json`,
   // registration_endpoint: 'https://server.example.com/connect/register',
   scopes_supported: ['openid', 'read:user', 'user:email'],
   response_types_supported: [

--- a/src/openid.test.js
+++ b/src/openid.test.js
@@ -12,7 +12,8 @@ describe('openid domain layer', () => {
   const githubMock = {
     getUserEmails: jest.fn(),
     getUserDetails: jest.fn(),
-    getToken: jest.fn()
+    getToken: jest.fn(),
+    getAuthorizeUrl: jest.fn()
   };
 
   beforeEach(() => {
@@ -132,6 +133,17 @@ describe('openid domain layer', () => {
       const mockKey = { key: 'mock' };
       crypto.getPublicKey.mockImplementation(() => mockKey);
       expect(openid.getJwks()).to.deep.equal({ keys: [mockKey] });
+    });
+  });
+  describe('authorization', () => {
+    beforeEach(() => {
+      githubMock.getAuthorizeUrl.mockImplementation((client_id, scope, state, response_type) =>
+        `https://not-a-real-host.com/authorize?client_id=${client_id}&scope=${scope}&state=${state}&response_type=${response_type}`
+      );
+    });
+    it('Redirects to the authorization URL', () => {
+      expect(openid.getAuthorizeUrl('client_id', 'scope', 'state', 'response_type')).to.equal(
+        'https://not-a-real-host.com/authorize?client_id=client_id&scope=scope&state=state&response_type=response_type')
     });
   });
   describe('openid-configuration', () => {

--- a/src/openid.test.js
+++ b/src/openid.test.js
@@ -155,7 +155,7 @@ describe('openid domain layer', () => {
           display_values_supported: ['page', 'popup'],
           id_token_signing_alg_values_supported: ['RS256'],
           issuer: 'https://not-a-real-host.com',
-          jwks_uri: 'https://not-a-real-host.com/jwks.json',
+          jwks_uri: 'https://not-a-real-host.com/.well-known/jwks.json',
           request_object_signing_alg_values_supported: ['none'],
           response_types_supported: [
             'code',

--- a/template.yml
+++ b/template.yml
@@ -16,6 +16,10 @@ Globals:
               Ref: GitHubClientSecretParameter
             COGNITO_REDIRECT_URI:
               Ref: CognitoRedirectUriParameter
+            GITHUB_API_URL:
+              Ref: GitHubUrlParameter
+            GITHUB_LOGIN_URL:
+              Ref: GitHubLoginUrlParameter
 
 Parameters:
   GitHubClientIdParameter:
@@ -23,6 +27,10 @@ Parameters:
   GitHubClientSecretParameter:
     Type: String
   CognitoRedirectUriParameter:
+    Type: String
+  GitHubUrlParameter:
+    Type: String
+  GitHubLoginUrlParameter:
     Type: String
 
 Resources:

--- a/template.yml
+++ b/template.yml
@@ -89,7 +89,7 @@ Resources:
         GetResource:
           Type: Api
           Properties:
-            Path: /jwks.json
+            Path: /.well-known/jwks.json
             Method: get
 
 Outputs:


### PR DESCRIPTION
This PR is to add support for GitHub Enterprise by letting the `github.com` URL to be configurable and remove hardcoded URLs from the code base.

Testcases have been added for this, too.

Also some minor issue where fixed along the way, each in its own commit:
* Properly generate the key on OSX 10.14
* Fix #14 as per the issue
* Discover the `stage name` in a Lambda deployment
* Update dependencies to solve known issues (`npm audit`)
