### PR TITLE
Moves GitHub url defaults into template.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Next you need to decide if you'd like to deploy with lambda/API Gateway (follow 
     - Authorization endpoint: `https://<Your API Gateway DNS name>/Prod/authorize`
     - Token endpoint: `https://<Your API Gateway DNS name>/Prod/token`
     - Userinfo endpoint: `https://<Your API Gateway DNS name>/Prod/userinfo`
-    - JWKS uri: `https://<Your API Gateway DNS name>/Prod/jwks.json`
+    - JWKS uri: `https://<Your API Gateway DNS name>/Prod/.well-known/jwks.json`
 - Configure the Attribute Mapping in the AWS console:
 
 ![Attribute mapping](docs/attribute-mapping.png)

--- a/src/github.js
+++ b/src/github.js
@@ -8,8 +8,8 @@ const {
 } = require('./config');
 
 const getApiEndpoints = (
-  apiBaseUrl = GITHUB_API_URL || 'https://api.github.com',
-  loginBaseUrl = GITHUB_LOGIN_URL || 'https://github.com'
+  apiBaseUrl = GITHUB_API_URL,
+  loginBaseUrl = GITHUB_LOGIN_URL
 ) => ({
   userDetails: `${apiBaseUrl}/user`,
   userEmails: `${apiBaseUrl}/user/emails`,

--- a/template.yml
+++ b/template.yml
@@ -30,8 +30,12 @@ Parameters:
     Type: String
   GitHubUrlParameter:
     Type: String
+    Default: "https://api.github.com"
+    MinLength: 1
   GitHubLoginUrlParameter:
     Type: String
+    Default: "https://github.com"
+    MinLength: 1
 
 Resources:
   OpenIdDiscovery:


### PR DESCRIPTION
The application code currently has defaults built in for these URLs. For example:

```
const getApiEndpoints = (apiBaseUrl = GITHUB_API_URL || 'https://api.github.com', 
                         loginBaseUrl = GITHUB_LOGIN_URL || 'https://github.com') => ({
```

This PR adds defaults for these urls as the empty string so that the previous defaults can still work. 

Another approach would be to move these defaults into `template.yml` instead of using an empty string. **Edit: Went with this approach**

Cheers!