### PR TITLE
AWS balked at nodejs10 because it wasn't in the enum

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -6,7 +6,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Runtime: nodejs10
+    Runtime: nodejs10.x
     Timeout: 15
     Environment:
       Variables:


### PR DESCRIPTION
They want it to be nodejs10.x