### PR TITLE
Fix/logging

### DIFF
--- a/example-config.sh
+++ b/example-config.sh
@@ -4,6 +4,9 @@
 export GITHUB_CLIENT_ID=# <GitHub OAuth App Client ID>
 export GITHUB_CLIENT_SECRET=# <GitHub OAuth App Client Secret>
 export COGNITO_REDIRECT_URI=# https://<Your Cognito Domain>/oauth2/idpresponse
+export GITHUB_API_URL="https://api.github.com"
+export GITHUB_LOGIN_URL="https://github.com"
+export NODE_LOG_LEVEL="debug"
 
 # Variables required if used with GitHub Enterprise
 # GITHUB_API_URL=# https://<GitHub Enterprise Host>/api/v3

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "webpack",
     "test": "jest --runInBand --coverage",
     "test-dev": "jest --runInBand --watch",
-    "start": "webpack --watch --display errors-only",
+    "start": "webpack --watch",
     "lint": "eslint 'src/**' --ext .js",
     "preinstall": "./scripts/create-key.sh",
     "prebuild-dist": "npm run lint && npm run test",

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ module.exports = {
   GITHUB_API_URL: process.env.GITHUB_API_URL,
   GITHUB_LOGIN_URL: process.env.GITHUB_LOGIN_URL,
   PORT: parseInt(process.env.PORT, 10) || undefined,
-
+  LOG_LEVEL: process.env.NODE_LOG_LEVEL,
   // Splunk logging variables
   SPLUNK_URL: process.env.SPLUNK_URL,
   SPLUNK_TOKEN: process.env.SPLUNK_TOKEN,

--- a/src/connectors/logger.js
+++ b/src/connectors/logger.js
@@ -4,11 +4,12 @@ const {
   SPLUNK_TOKEN,
   SPLUNK_SOURCE,
   SPLUNK_SOURCETYPE,
-  SPLUNK_INDEX
+  SPLUNK_INDEX,
+  LOG_LEVEL
 } = require('../config');
 
 const logger = winston.createLogger({
-  level: 'info'
+  level: LOG_LEVEL || 'info'
 });
 
 // Activate Splunk logging if Splunk's env variables are set


### PR DESCRIPTION
Without these envs in `config.sh` the wrapper fails in web mode:
```
export GITHUB_API_URL="https://api.github.com"
export GITHUB_LOGIN_URL="https://github.com"
```

I'll create a draft PR since I have a naive logger there that should be removed and you might want to have an input on how that is implemented for `getUserEmails`. 